### PR TITLE
Support Python 2.6 for RHEL/CentOS 6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- metrics-jstat.py: support added for py2.6 (RHEL/CentOS 6.x)
 
 ## [0.0.4] - 2016-04-26
 ### Changed

--- a/bin/metrics-jstat.py
+++ b/bin/metrics-jstat.py
@@ -35,9 +35,51 @@
 import logging
 import logging.handlers
 import optparse
-from subprocess import check_output
 import sys
 import time
+
+"""
+Python 2.6 support for check_output:
+http://stackoverflow.com/questions/4814970/subprocess-check-output-doesnt-seem-to-exist-python-2-6-5
+"""
+try:
+    from subprocess import STDOUT, check_output, CalledProcessError
+except ImportError:  # pragma: no cover
+    # python 2.6 doesn't include check_output
+    # monkey patch it in!
+    import subprocess
+    STDOUT = subprocess.STDOUT
+
+    def check_output(*popenargs, **kwargs):
+        if 'stdout' in kwargs:  # pragma: no cover
+            raise ValueError('stdout argument not allowed, '
+                             'it will be overridden.')
+        process = subprocess.Popen(stdout=subprocess.PIPE,
+                                   *popenargs, **kwargs)
+        output, _ = process.communicate()
+        retcode = process.poll()
+        if retcode:
+            cmd = kwargs.get("args")
+            if cmd is None:
+                cmd = popenargs[0]
+            raise subprocess.CalledProcessError(retcode, cmd,
+                                                output=output)
+        return output
+    subprocess.check_output = check_output
+
+    # overwrite CalledProcessError due to `output`
+    # keyword not being available (in 2.6)
+    class CalledProcessError(Exception):
+
+        def __init__(self, returncode, cmd, output=None):
+            self.returncode = returncode
+            self.cmd = cmd
+            self.output = output
+
+        def __str__(self):
+            return "Command '%s' returned non-zero exit status %d" % (
+                self.cmd, self.returncode)
+    subprocess.CalledProcessError = CalledProcessError
 
 class JstatMetricsToGraphiteFormat(object):
   '''Prints jstat metrics to stdout in graphite format


### PR DESCRIPTION
## Pull Request Checklist

Issue: https://github.com/sensu-plugins/sensu-plugins-java/issues/4

Monkey patch from stack overflow comment:
http://stackoverflow.com/questions/4814970/subprocess-check-output-doesnt-seem-to-exist-python-2-6-5
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets

N/a
- [x] Binstubs are created if needed

N/a
- [x] RuboCop passes

N/a
- [x] Existing tests pass 

Manually tested function.
#### Purpose

Resolve py26 support.
#### Known Compatibility Issues

None
