### PR TITLE
enclose name with double quotes while searching

### DIFF
--- a/bin/check-java-heap-pcnt-java8.sh
+++ b/bin/check-java-heap-pcnt-java8.sh
@@ -50,7 +50,7 @@ JAVA_BIN=${JAVA_BIN:=""}
 
 #Get PIDs of JVM.
 #At this point grep for the names of the java processes running your jvm.
-PIDS=$(sudo ${JAVA_BIN}jps $OPTIONS | grep $NAME | awk '{ print $1}')
+PIDS=$(sudo ${JAVA_BIN}jps $OPTIONS | grep "$NAME" | awk '{ print $1}')
 
 projectSize=$(printf "%s\n" $(printf "$PIDS" | wc -w))
 

--- a/bin/check-java-heap-pcnt.sh
+++ b/bin/check-java-heap-pcnt.sh
@@ -49,7 +49,7 @@ JAVA_BIN=${JAVA_BIN:=""}
 
 #Get PID of JVM.
 #At this point grep for the name of the java process running your jvm.
-PID=$(sudo ${JAVA_BIN}jps $OPTIONS | grep $NAME | awk '{ print $1}')
+PID=$(sudo ${JAVA_BIN}jps $OPTIONS | grep "$NAME" | awk '{ print $1}')
 
 #Get heap capacity of JVM
 TotalHeap=$(sudo ${JAVA_BIN}jstat -gccapacity $PID  | tail -n 1 | awk '{ print ($4 + $5 + $6 + $10) / 1024 }')

--- a/bin/java-heap-pcnt.sh
+++ b/bin/java-heap-pcnt.sh
@@ -45,7 +45,7 @@ NAME=${NAME:=0}
 
 #Get PID of JVM.
 #At this point grep for the name of the java process running your jvm.
-PID=$(sudo jps | grep $NAME | awk '{ print $1}')
+PID=$(sudo jps | grep "$NAME" | awk '{ print $1}')
 
 #Get heap capacity of JVM
 TotalHeap=$(sudo jstat -gccapacity $PID  | tail -n 1 | awk '{ print ($4 + $5 + $6 + $10) / 1024 }')

--- a/bin/metrics-java-heap-graphite-java8.sh
+++ b/bin/metrics-java-heap-graphite-java8.sh
@@ -34,7 +34,7 @@ NAME=${NAME:=0}
 
 #Get PIDs of JVM.
 #At this point grep for the names of the java processes running your jvm.
-PID=$(sudo jps | grep $NAME | awk '{ print $1}')
+PID=$(sudo jps | grep "$NAME" | awk '{ print $1}')
 for PID in $PIDS
 do
   #Get heap capacity of JVM

--- a/bin/metrics-java-heap-graphite.sh
+++ b/bin/metrics-java-heap-graphite.sh
@@ -34,7 +34,7 @@ NAME=${NAME:=0}
 
 #Get PID of JVM.
 #At this point grep for the name of the java process running your jvm.
-PID=$(sudo jps | grep $NAME | awk '{ print $1}')
+PID=$(sudo jps | grep "$NAME" | awk '{ print $1}')
 
 #Get heap capacity of JVM
 TotalHeap=$(sudo jstat -gccapacity $PID  | tail -n 1 | awk '{ print ($4 + $5 + $6 + $10) / 1024 }')


### PR DESCRIPTION
if there are following two java processes:
    1234 NameNode
    5678 SecondaryNameNode
this fix allows to select NameNode process as below:
    check-java-heap-pcnt.sh -n ' NameNode'

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

